### PR TITLE
Use gudev and libnotify modules from runtime

### DIFF
--- a/net.sourceforge.roccat.roccat-tools.yml
+++ b/net.sourceforge.roccat.roccat-tools.yml
@@ -20,17 +20,6 @@ modules:
   - shared-modules/libcanberra/libcanberra.json
   - shared-modules/gtk2/gtk2.json
   - shared-modules/dbus-glib/dbus-glib.json
-  - shared-modules/gudev/gudev.json
-
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dman=false
-      - -Dgtk_doc=false
-    sources:
-      - type: archive
-        url: https://gitlab.gnome.org/GNOE/libnotify/-/archive/0.8.2/libnotify-0.8.2.tar.gz
-        sha256: 84d6bbcd633ff10eed25226730c52220cd41e362bb183513e5b6a5d1b3c0c12f
 
   - name: libgaminggear
     buildsystem: cmake-ninja


### PR DESCRIPTION
Freedesktop runtime version 24.08 appears to provide the libgudev/gudev and libnotify modules.

Fixes: https://github.com/flathub/net.sourceforge.roccat.roccat-tools/issues/15
Fixes: https://github.com/flathub/net.sourceforge.roccat.roccat-tools/issues/13